### PR TITLE
Removed v4 build support

### DIFF
--- a/.github/workflows/release-server-versions-for-int-store.yml
+++ b/.github/workflows/release-server-versions-for-int-store.yml
@@ -3,37 +3,16 @@ name: Release Server Versions For Integration Store
 on:
   workflow_call:
     inputs:
-      node-12-version:
-        description: 'The Node Version for the Oldest Supported Polarity Node Server Version'
-        required: false
-        type: string
-        default: '12'
-      node-14-version:
-        description: 'The Node Version for the Newest Supported Polarity Node Server Version'
-        required: false
-        type: string
-        default: '14'
       node-18-version:
         description: 'The Node Version for the Polarity Elixir Server Version'
         required: false
         type: string
         default: '18'
-
-      node-polarity-server-os-version:
-        description: 'The Operating System for both the Node 12 and 14 Polarity Node Servers'
-        required: false
-        type: string
-        default: ubuntu-latest
-      node-polarity-servers-container-version:
-        description: 'The Container Version for both the Node 12 and 14 Polarity Node Servers'
-        required: false
-        type: string
-        default: rockylinux:8
       elixir-server-os-version:
         description: 'The Node Version for the Polarity Elixir Server Version'
         required: false
         type: string
-        default: ubuntu-22.04
+        default: ubuntu-latest
       use-integration-development-checklist:
         description: 'A Flag to disable the integration development checklist requirement to create a release'
         required: false
@@ -41,86 +20,6 @@ on:
         default: true
 
 jobs:
-  Node12PolarityServerRelease:
-    runs-on: ${{ inputs.node-polarity-server-os-version }}
-    container: ${{ inputs.node-polarity-servers-container-version }}
-    steps:
-      - name: Install Git
-        run: yum install git -y
-      - name: Install Git LFS
-        run: yum install git-lfs -y
-      - uses: actions/checkout@v2
-        with:
-          lfs: true
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ inputs.node-12-version }}
-      - name: Get NPM Version
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@95bc31c6dd3145896c110e382f840bb1e750d09c
-      - name: Create Build
-        id: create-build
-        run: |
-          npm ci --production --no-bin-links &&
-          cd .. && 
-          tar --exclude="./${{ github.event.repository.name }}/.git" --exclude="./${{ github.event.repository.name }}/.gitignore" --exclude="./${{ github.event.repository.name }}/.github" -czvf "${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-12-version }}.tgz" "./${{ github.event.repository.name }}" &&  
-          echo "buildHash=$(sha256sum '${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-12-version }}.tgz' | grep -oE '^[^ ]*' )" >> $GITHUB_ENV &&
-          mv "${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-12-version }}.tgz" ${{ github.event.repository.name }} &&
-          cd ${{ github.event.repository.name }}
-      - name: Polarity Integration Development Checklist
-        if: ${{inputs.use-integration-development-checklist}}
-        id: int-dev-checklist
-        uses: polarityio/polarity-integration-development-checklist@main
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Adding SHA256 Hash For Polarity Node 12 Server Release
-        run: |
-          echo "${{ env.buildHash }}" > polarityNode12ServerReleaseSHA256Hash.txt
-      - name: Upload polarityNode12ServerReleaseSHA256Hash
-        uses: actions/upload-artifact@v4
-        with:
-          name: polarityNode12ServerReleaseSHA256Hash
-          path: polarityNode12ServerReleaseSHA256Hash.txt
-      - name: Upload polarityNode12ServerReleaseZip
-        uses: actions/upload-artifact@v4
-        with:
-          name: polarityNode12ServerReleaseZip
-          path: ${{ github.event.repository.name }}-${{steps.package-version.outputs.current-version}}+node-${{ inputs.node-12-version }}.tgz
-
-  # Node14PolarityServerRelease:
-  #   runs-on: ${{ inputs.node-polarity-server-os-version }}
-  #   container: ${{ inputs.node-polarity-servers-container-version }}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-node@v3
-  #       with:
-  #         node-version: ${{ inputs.node-14-version }}
-  #     - name: Get NPM Version
-  #       id: package-version
-  #       uses: martinbeentjes/npm-get-version-action@95bc31c6dd3145896c110e382f840bb1e750d09c
-  #     - name: Create Build
-  #       id: create-build
-  #       run: |
-  #         npm ci &&
-  #         cd .. && 
-  #         tar --exclude="./${{ github.event.repository.name }}/.git" --exclude="./${{ github.event.repository.name }}/.gitignore" --exclude="./${{ github.event.repository.name }}/.github" -czvf "${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-14-version }}.tgz" "./${{ github.event.repository.name }}" &&  
-  #         echo "buildHash=$(sha256sum '${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-14-version }}.tgz' | grep -oE '^[^ ]*' )" >> $GITHUB_ENV &&
-  #         mv "${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-14-version }}.tgz" ${{ github.event.repository.name }} &&
-  #         cd ${{ github.event.repository.name }}
-  #     - name: Adding SHA256 Hash For Release
-  #       run: |
-  #         echo "${{ env.buildHash }}" > polarityNode14ServerReleaseSHA256Hash.txt
-  #     - name: Upload polarityNode14ServerReleaseSHA256Hash
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: polarityNode14ServerReleaseSHA256Hash
-  #         path: polarityNode14ServerReleaseSHA256Hash.txt
-  #     - name: Upload polarityNode14ServerReleaseZip
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: polarityNode14ServerReleaseZip
-  #         path: ${{ github.event.repository.name }}-${{steps.package-version.outputs.current-version}}+node-${{ inputs.node-14-version }}.tgz
-
   Node18PolarityServerRelease:
     runs-on: ${{ inputs.elixir-server-os-version }}
     steps:
@@ -160,8 +59,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       [
-        Node12PolarityServerRelease,
-        # Node14PolarityServerRelease,
         Node18PolarityServerRelease
       ]
     steps:
@@ -173,39 +70,16 @@ jobs:
         id: package-version
         uses: martinbeentjes/npm-get-version-action@95bc31c6dd3145896c110e382f840bb1e750d09c
 
-      - name: Download polarityNode12ServerReleaseSHA256Hash
-        uses: actions/download-artifact@v4
-        with:
-          name: polarityNode12ServerReleaseSHA256Hash
-      - name: Add polarityNode12ServerReleaseSHA256Hash to ENV for use
-        run: |
-          value=`cat polarityNode12ServerReleaseSHA256Hash.txt`
-          echo "polarityNode12ServerReleaseSHA256Hash=$value" >> $GITHUB_ENV
-      # - name: Download polarityNode14ServerReleaseSHA256Hash
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: polarityNode14ServerReleaseSHA256Hash
-      # - name: Add polarityNode14ServerReleaseSHA256Hash to ENV for use
-      #   run: |
-      #     value=`cat polarityNode14ServerReleaseSHA256Hash.txt`
-      #     echo "polarityNode14ServerReleaseSHA256Hash=$value" >> $GITHUB_ENV
       - name: Download Node18PolarityServerReleaseSHA256Hash
         uses: actions/download-artifact@v4
         with:
           name: Node18PolarityServerReleaseSHA256Hash
+
       - name: Add Node18PolarityServerReleaseSHA256Hash to ENV for use
         run: |
           value=`cat Node18PolarityServerReleaseSHA256Hash.txt`
           echo "Node18PolarityServerReleaseSHA256Hash=$value" >> $GITHUB_ENV
 
-      - name: Download polarityNode12ServerReleaseZip
-        uses: actions/download-artifact@v4
-        with:
-          name: polarityNode12ServerReleaseZip
-      # - name: Download polarityNode14ServerReleaseZip
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: polarityNode14ServerReleaseZip
       - name: Download Node18PolarityServerReleaseZip
         uses: actions/download-artifact@v4
         with:
@@ -231,11 +105,7 @@ jobs:
             ${{ env.commitLogs }}
             
             ## Downloads
-
-            **Polarity Server 4.x**
-            - DOWNLOAD: [${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-12-version }}.tgz](https://github.com/polarityio/${{ github.event.repository.name }}/releases/download/${{ steps.package-version.outputs.current-version }}/${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-12-version }}.tgz)
-            SHA256: ${{ env.polarityNode12ServerReleaseSHA256Hash }}
-            
+           
             **Polarity Server 5.x**
             - DOWNLOAD: [${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-18-version }}.tgz](https://github.com/polarityio/${{ github.event.repository.name }}/releases/download/${{ steps.package-version.outputs.current-version }}/${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-18-version }}.tgz)
             SHA256: ${{ env.Node18PolarityServerReleaseSHA256Hash }}
@@ -243,9 +113,7 @@ jobs:
           # - DOWNLOAD: [${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-14-version }}.tgz](https://github.com/polarityio/${{ github.event.repository.name }}/releases/download/${{ steps.package-version.outputs.current-version }}/${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-14-version }}.tgz)
           # SHA256: ${{ env.polarityNode14ServerReleaseSHA256Hash }}
           files: |
-            ./${{ github.event.repository.name }}-${{steps.package-version.outputs.current-version}}+node-${{ inputs.node-12-version }}.tgz
             ./${{ github.event.repository.name }}-${{steps.package-version.outputs.current-version}}+node-${{ inputs.node-18-version }}.tgz
-          # ./${{ github.event.repository.name }}-${{steps.package-version.outputs.current-version}}+node-${{ inputs.node-14-version }}.tgz
           draft: false
           prerelease: false
           generate_release_notes: false


### PR DESCRIPTION
This update removes v4 build support.

Tested using the github-actions-test repo.  You can see the built integration released here:

https://github.com/polarityio/testing-github-actions/releases/tag/3.2.22

I tested the integration on our test server and everything built correctly.

