### PR TITLE
Add support for v2 integration builds

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -244,7 +244,7 @@ jobs:
           name: ${{ steps.package-version.outputs.current-version }}
           tag_name: ${{ steps.package-version.outputs.current-version }}
           body: |
-            > **This is a v2 integration pre-release.**
+            > **This is a v2 integration framework pre-release.**
 
             ## Release Notes
             ${{ env.commitLogs }}

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       is_v2: ${{ steps.check-config.outputs.is_v2 }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check for runtimeVersion in config
         id: check-config
         run: |
@@ -60,15 +60,15 @@ jobs:
     if: needs.detect-version.outputs.is_v2 == 'false'
     runs-on: ${{ inputs.os-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
       - name: Get NPM Version
         id: package-version
-        uses: martinbeentjes/npm-get-version-action@95bc31c6dd3145896c110e382f840bb1e750d09c
+        run: echo "current-version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Create Build
         id: create-build
         run: |
@@ -97,13 +97,13 @@ jobs:
     needs: [detect-version, v1-build]
     if: needs.detect-version.outputs.is_v2 == 'false'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - name: Get NPM Version
         id: package-version
-        uses: martinbeentjes/npm-get-version-action@95bc31c6dd3145896c110e382f840bb1e750d09c
+        run: echo "current-version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Download ReleaseSHA256Hash
         uses: actions/download-artifact@v4
         with:
@@ -127,7 +127,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
       - name: Create Versioned Release
         id: create-versioned-release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: ${{ steps.package-version.outputs.current-version }}
           tag_name: ${{ steps.package-version.outputs.current-version }}
@@ -158,25 +158,25 @@ jobs:
     if: needs.detect-version.outputs.is_v2 == 'true'
     runs-on: ${{ inputs.os-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
       - name: Get NPM Version
         id: package-version
-        uses: martinbeentjes/npm-get-version-action@95bc31c6dd3145896c110e382f840bb1e750d09c
+        run: echo "current-version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Install Dependencies
         run: |
           npm ci
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-build-version }}
       - name: Build
         run: |
           npm run build
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
       - name: Reinstall Production Dependencies Only
@@ -209,13 +209,13 @@ jobs:
     needs: [detect-version, v2-build]
     if: needs.detect-version.outputs.is_v2 == 'true'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - name: Get NPM Version
         id: package-version
-        uses: martinbeentjes/npm-get-version-action@95bc31c6dd3145896c110e382f840bb1e750d09c
+        run: echo "current-version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Download ReleaseSHA256Hash
         uses: actions/download-artifact@v4
         with:
@@ -239,7 +239,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
       - name: Create Versioned Release
         id: create-versioned-release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: ${{ steps.package-version.outputs.current-version }}
           tag_name: ${{ steps.package-version.outputs.current-version }}

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       is_v2: ${{ steps.check-config.outputs.is_v2 }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check for runtimeVersion in config
         id: check-config
         run: |
@@ -60,10 +60,10 @@ jobs:
     if: needs.detect-version.outputs.is_v2 == 'false'
     runs-on: ${{ inputs.os-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ inputs.node-version }}
       - name: Get NPM Version
@@ -82,12 +82,12 @@ jobs:
         run: |
           echo "${{ env.buildHash }}" > ReleaseSHA256Hash.txt
       - name: Upload ReleaseSHA256Hash
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ReleaseSHA256Hash
           path: ReleaseSHA256Hash.txt
       - name: Upload ReleaseArchive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ReleaseArchive
           path: ${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-version }}.tgz
@@ -97,15 +97,15 @@ jobs:
     needs: [detect-version, v1-build]
     if: needs.detect-version.outputs.is_v2 == 'false'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: '0'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
       - name: Get NPM Version
         id: package-version
         run: echo "current-version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Download ReleaseSHA256Hash
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ReleaseSHA256Hash
       - name: Add ReleaseSHA256Hash to ENV for use
@@ -113,7 +113,7 @@ jobs:
           value=`cat ReleaseSHA256Hash.txt`
           echo "ReleaseSHA256Hash=$value" >> $GITHUB_ENV
       - name: Download ReleaseArchive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ReleaseArchive
       - name: Getting Git Commit Logs Since Last Release
@@ -158,10 +158,10 @@ jobs:
     if: needs.detect-version.outputs.is_v2 == 'true'
     runs-on: ${{ inputs.os-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ inputs.node-version }}
       - name: Get NPM Version
@@ -170,13 +170,13 @@ jobs:
       - name: Install Dependencies
         run: |
           npm ci
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ inputs.node-build-version }}
       - name: Build
         run: |
           npm run build
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ inputs.node-version }}
       - name: Reinstall Production Dependencies Only
@@ -194,12 +194,12 @@ jobs:
         run: |
           echo "${{ env.buildHash }}" > ReleaseSHA256Hash.txt
       - name: Upload ReleaseSHA256Hash
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ReleaseSHA256Hash
           path: ReleaseSHA256Hash.txt
       - name: Upload ReleaseArchive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ReleaseArchive
           path: ${{ github.event.repository.name }}-v2-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-version }}.tgz
@@ -209,15 +209,15 @@ jobs:
     needs: [detect-version, v2-build]
     if: needs.detect-version.outputs.is_v2 == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: '0'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
       - name: Get NPM Version
         id: package-version
         run: echo "current-version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Download ReleaseSHA256Hash
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ReleaseSHA256Hash
       - name: Add ReleaseSHA256Hash to ENV for use
@@ -225,7 +225,7 @@ jobs:
           value=`cat ReleaseSHA256Hash.txt`
           echo "ReleaseSHA256Hash=$value" >> $GITHUB_ENV
       - name: Download ReleaseArchive
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: ReleaseArchive
       - name: Getting Git Commit Logs Since Last Release

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -1,0 +1,264 @@
+name: Release Integration
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: 'The Node version for v1 builds and v2 dependency installation'
+        required: false
+        type: string
+        default: '18'
+      node-build-version:
+        description: 'The Node version used for v2 npm run build'
+        required: false
+        type: string
+        default: '24'
+      os-version:
+        description: 'The OS version for the build runner'
+        required: false
+        type: string
+        default: ubuntu-latest
+      use-integration-development-checklist:
+        description: 'A flag to disable the integration development checklist requirement to create a release'
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+  detect-version:
+    runs-on: ubuntu-latest
+    outputs:
+      is_v2: ${{ steps.check-config.outputs.is_v2 }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check for runtimeVersion in config
+        id: check-config
+        run: |
+          CONFIG_FILE="config/config.json"
+          if [ ! -f "$CONFIG_FILE" ]; then
+            echo "is_v2=false" >> $GITHUB_OUTPUT
+            echo "No config/config.json found — using v1 workflow."
+            exit 0
+          fi
+
+          RUNTIME_VERSION=$(node -p "try { const c = require('./$CONFIG_FILE'); c.runtimeVersion ?? 'undefined' } catch(e) { 'undefined' }" 2>/dev/null || echo "undefined")
+
+          if [ "$RUNTIME_VERSION" = "2" ]; then
+            echo "is_v2=true" >> $GITHUB_OUTPUT
+            echo "runtimeVersion is 2 — using v2 workflow."
+          else
+            echo "is_v2=false" >> $GITHUB_OUTPUT
+            echo "runtimeVersion is '$RUNTIME_VERSION' — using v1 workflow."
+          fi
+
+  # ──────────────────────────────────────────────
+  # V1 Build & Release
+  # ──────────────────────────────────────────────
+
+  v1-build:
+    needs: detect-version
+    if: needs.detect-version.outputs.is_v2 == 'false'
+    runs-on: ${{ inputs.os-version }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.node-version }}
+      - name: Get NPM Version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@95bc31c6dd3145896c110e382f840bb1e750d09c
+      - name: Create Build
+        id: create-build
+        run: |
+          npm ci --omit=dev --no-bin-links &&
+          cd .. && 
+          tar --exclude="./${{ github.event.repository.name }}/.git" --exclude="./${{ github.event.repository.name }}/.gitignore" --exclude="./${{ github.event.repository.name }}/.github" -czvf "${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-version }}.tgz" "./${{ github.event.repository.name }}" &&  
+          echo "buildHash=$(sha256sum '${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-version }}.tgz' | grep -oE '^[^ ]*' )" >> $GITHUB_ENV &&
+          mv "${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-version }}.tgz" ${{ github.event.repository.name }} &&
+          cd ${{ github.event.repository.name }}
+      - name: Adding SHA256 Hash For Release
+        run: |
+          echo "${{ env.buildHash }}" > ReleaseSHA256Hash.txt
+      - name: Upload ReleaseSHA256Hash
+        uses: actions/upload-artifact@v4
+        with:
+          name: ReleaseSHA256Hash
+          path: ReleaseSHA256Hash.txt
+      - name: Upload ReleaseArchive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ReleaseArchive
+          path: ${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-version }}.tgz
+
+  v1-release:
+    runs-on: ubuntu-latest
+    needs: [detect-version, v1-build]
+    if: needs.detect-version.outputs.is_v2 == 'false'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+      - uses: actions/setup-node@v3
+      - name: Get NPM Version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@95bc31c6dd3145896c110e382f840bb1e750d09c
+      - name: Download ReleaseSHA256Hash
+        uses: actions/download-artifact@v4
+        with:
+          name: ReleaseSHA256Hash
+      - name: Add ReleaseSHA256Hash to ENV for use
+        run: |
+          value=`cat ReleaseSHA256Hash.txt`
+          echo "ReleaseSHA256Hash=$value" >> $GITHUB_ENV
+      - name: Download ReleaseArchive
+        uses: actions/download-artifact@v4
+        with:
+          name: ReleaseArchive
+      - name: Getting Git Commit Logs Since Last Release
+        run: |
+          echo "$(git log $(git tag -l | cat | tail -1)..HEAD --oneline | cat | awk '{$1="-"; print $0}')" > commitLogs.txt
+      - name: Add commitLogs to ENV for use
+        run: |
+          commitLogs=$(cat commitLogs.txt)
+          echo "commitLogs<<EOF" >> $GITHUB_ENV
+          echo "$commitLogs" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: Create Versioned Release
+        id: create-versioned-release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ steps.package-version.outputs.current-version }}
+          tag_name: ${{ steps.package-version.outputs.current-version }}
+          body: |
+            ## Release Notes
+            ${{ env.commitLogs }}
+            
+            ## Downloads
+           
+            **Polarity Server 5.x**
+            - DOWNLOAD: [${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-version }}.tgz](https://github.com/polarityio/${{ github.event.repository.name }}/releases/download/${{ steps.package-version.outputs.current-version }}/${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-version }}.tgz)
+            SHA256: ${{ env.ReleaseSHA256Hash }}
+          files: |
+            ./${{ github.event.repository.name }}-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-version }}.tgz
+          draft: false
+          prerelease: false
+          make_latest: true
+          generate_release_notes: false
+          append_body: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  # ──────────────────────────────────────────────
+  # V2 Build & Release
+  # ──────────────────────────────────────────────
+
+  v2-build:
+    needs: detect-version
+    if: needs.detect-version.outputs.is_v2 == 'true'
+    runs-on: ${{ inputs.os-version }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.node-version }}
+      - name: Get NPM Version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@95bc31c6dd3145896c110e382f840bb1e750d09c
+      - name: Install Dependencies
+        run: |
+          npm ci
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.node-build-version }}
+      - name: Build
+        run: |
+          npm run build
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.node-version }}
+      - name: Reinstall Production Dependencies Only
+        run: |
+          npm ci --omit=dev --no-bin-links
+      - name: Create Build Archive
+        id: create-build
+        run: |
+          cd .. &&
+          tar --exclude="./${{ github.event.repository.name }}/.git" --exclude="./${{ github.event.repository.name }}/.gitignore" --exclude="./${{ github.event.repository.name }}/.github" -czvf "${{ github.event.repository.name }}-v2-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-version }}.tgz" "./${{ github.event.repository.name }}" &&
+          echo "buildHash=$(sha256sum '${{ github.event.repository.name }}-v2-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-version }}.tgz' | grep -oE '^[^ ]*' )" >> $GITHUB_ENV &&
+          mv "${{ github.event.repository.name }}-v2-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-version }}.tgz" ${{ github.event.repository.name }} &&
+          cd ${{ github.event.repository.name }}
+      - name: Adding SHA256 Hash For Release
+        run: |
+          echo "${{ env.buildHash }}" > ReleaseSHA256Hash.txt
+      - name: Upload ReleaseSHA256Hash
+        uses: actions/upload-artifact@v4
+        with:
+          name: ReleaseSHA256Hash
+          path: ReleaseSHA256Hash.txt
+      - name: Upload ReleaseArchive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ReleaseArchive
+          path: ${{ github.event.repository.name }}-v2-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-version }}.tgz
+
+  v2-release:
+    runs-on: ubuntu-latest
+    needs: [detect-version, v2-build]
+    if: needs.detect-version.outputs.is_v2 == 'true'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+      - uses: actions/setup-node@v3
+      - name: Get NPM Version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@95bc31c6dd3145896c110e382f840bb1e750d09c
+      - name: Download ReleaseSHA256Hash
+        uses: actions/download-artifact@v4
+        with:
+          name: ReleaseSHA256Hash
+      - name: Add ReleaseSHA256Hash to ENV for use
+        run: |
+          value=`cat ReleaseSHA256Hash.txt`
+          echo "ReleaseSHA256Hash=$value" >> $GITHUB_ENV
+      - name: Download ReleaseArchive
+        uses: actions/download-artifact@v4
+        with:
+          name: ReleaseArchive
+      - name: Getting Git Commit Logs Since Last Release
+        run: |
+          echo "$(git log $(git tag -l | cat | tail -1)..HEAD --oneline | cat | awk '{$1="-"; print $0}')" > commitLogs.txt
+      - name: Add commitLogs to ENV for use
+        run: |
+          commitLogs=$(cat commitLogs.txt)
+          echo "commitLogs<<EOF" >> $GITHUB_ENV
+          echo "$commitLogs" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+      - name: Create Versioned Release
+        id: create-versioned-release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ steps.package-version.outputs.current-version }}
+          tag_name: ${{ steps.package-version.outputs.current-version }}
+          body: |
+            > **This is a v2 integration pre-release.**
+
+            ## Release Notes
+            ${{ env.commitLogs }}
+
+            ## Downloads
+
+            **Polarity Server 5.x (v2 Integration)**
+            - DOWNLOAD: [${{ github.event.repository.name }}-v2-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-version }}.tgz](https://github.com/polarityio/${{ github.event.repository.name }}/releases/download/${{ steps.package-version.outputs.current-version }}/${{ github.event.repository.name }}-v2-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-version }}.tgz)
+            SHA256: ${{ env.ReleaseSHA256Hash }}
+          files: |
+            ./${{ github.event.repository.name }}-v2-${{ steps.package-version.outputs.current-version }}+node-${{ inputs.node-version }}.tgz
+          draft: false
+          prerelease: true
+          make_latest: false
+          generate_release_notes: false
+          append_body: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-server-versions-for-int-store.yml
+++ b/.github/workflows/release-server-versions-for-int-store.yml
@@ -23,10 +23,10 @@ jobs:
   Node18PolarityServerRelease:
     runs-on: ${{ inputs.elixir-server-os-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ inputs.node-18-version }}
       - name: Get NPM Version
@@ -45,12 +45,12 @@ jobs:
         run: |
           echo "${{ env.buildHash }}" > Node18PolarityServerReleaseSHA256Hash.txt
       - name: Upload Node18PolarityServerReleaseSHA256Hash
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Node18PolarityServerReleaseSHA256Hash
           path: Node18PolarityServerReleaseSHA256Hash.txt
       - name: Upload Node18PolarityServerReleaseZip
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Node18PolarityServerReleaseZip
           path: ${{ github.event.repository.name }}-${{steps.package-version.outputs.current-version}}+node-${{ inputs.node-18-version }}.tgz
@@ -62,16 +62,16 @@ jobs:
         Node18PolarityServerRelease
       ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: '0'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
       - name: Get NPM Version
         id: package-version
         run: echo "current-version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Download Node18PolarityServerReleaseSHA256Hash
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: Node18PolarityServerReleaseSHA256Hash
 
@@ -81,7 +81,7 @@ jobs:
           echo "Node18PolarityServerReleaseSHA256Hash=$value" >> $GITHUB_ENV
 
       - name: Download Node18PolarityServerReleaseZip
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: Node18PolarityServerReleaseZip
 

--- a/.github/workflows/release-server-versions-for-int-store.yml
+++ b/.github/workflows/release-server-versions-for-int-store.yml
@@ -23,15 +23,15 @@ jobs:
   Node18PolarityServerRelease:
     runs-on: ${{ inputs.elixir-server-os-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-18-version }}
       - name: Get NPM Version
         id: package-version
-        uses: martinbeentjes/npm-get-version-action@95bc31c6dd3145896c110e382f840bb1e750d09c
+        run: echo "current-version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
       - name: Create Build
         id: create-build
         run: |
@@ -62,13 +62,13 @@ jobs:
         Node18PolarityServerRelease
       ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - name: Get NPM Version
         id: package-version
-        uses: martinbeentjes/npm-get-version-action@95bc31c6dd3145896c110e382f840bb1e750d09c
+        run: echo "current-version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Download Node18PolarityServerReleaseSHA256Hash
         uses: actions/download-artifact@v4
@@ -96,7 +96,7 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
       - name: Create Versioned Release
         id: create-versioned-release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: ${{steps.package-version.outputs.current-version}}
           tag_name: ${{steps.package-version.outputs.current-version}}

--- a/.github/workflows/run-organization-action.yml
+++ b/.github/workflows/run-organization-action.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
       - name: Make Changes to Multiple Organization Repositories
         id: change_repos
         uses: ./

--- a/.github/workflows/run-organization-action.yml
+++ b/.github/workflows/run-organization-action.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
       - name: Make Changes to Multiple Organization Repositories
         id: change_repos
         uses: ./

--- a/src/individualRepoActions/release-current-version.yml
+++ b/src/individualRepoActions/release-current-version.yml
@@ -2,10 +2,8 @@ name: Release Current Version
 
 on:
   push:
-    branches: [ master, main ]
+    branches: [ master, main, support/v1 ]
 
 jobs:
   Run:
-    uses: polarityio/polarity-github-actions/.github/workflows/release-server-versions-for-int-store.yml@master
-    # with: 
-      # use-integration-development-checklist: false
+    uses: polarityio/polarity-github-actions/.github/workflows/release-integration.yml@master

--- a/src/individualRepoActions/run-int-dev-checklist.yml
+++ b/src/individualRepoActions/run-int-dev-checklist.yml
@@ -2,9 +2,44 @@ name: Run Integration Development Checklist
 
 on:
   pull_request:
-    branches: [ master, main, develop ]
+    branches: [ master, main, develop, support/v1 ]
 
 jobs:
+  version-safety-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check runtimeVersion compatibility with target branch
+        run: |
+          CONFIG_FILE="config/config.json"
+
+          if [ ! -f "$CONFIG_FILE" ]; then
+            echo "No config/config.json found — skipping version safety check."
+            exit 0
+          fi
+
+          RUNTIME_VERSION=$(node -p "try { const c = require('./$CONFIG_FILE'); c.runtimeVersion ?? 'undefined' } catch(e) { 'undefined' }" 2>/dev/null || echo "undefined")
+          TARGET_BRANCH="${{ github.base_ref }}"
+
+          echo "Target branch: $TARGET_BRANCH"
+          echo "runtimeVersion: $RUNTIME_VERSION"
+
+          if [ "$TARGET_BRANCH" = "support/v1" ]; then
+            if [ "$RUNTIME_VERSION" = "2" ]; then
+              echo "::error::Cannot merge a v2 integration (runtimeVersion: 2) into the support/v1 branch."
+              exit 1
+            fi
+            echo "Target is support/v1 and runtimeVersion is not 2 — OK."
+          fi
+
+          if [ "$TARGET_BRANCH" = "master" ] || [ "$TARGET_BRANCH" = "main" ]; then
+            if [ "$RUNTIME_VERSION" != "undefined" ] && [ "$RUNTIME_VERSION" != "2" ]; then
+              echo "::error::runtimeVersion is set to '$RUNTIME_VERSION' but must be '2' for merges into $TARGET_BRANCH."
+              exit 1
+            fi
+            echo "Target is $TARGET_BRANCH — runtimeVersion check passed."
+          fi
+
   run-integration-development-checklist:
     runs-on: ubuntu-latest
     container: 'centos:7'


### PR DESCRIPTION
## PR Changes
 - Added new release-integration.yml reusable workflow supporting both v1 and v2 integration builds/releases
﻿- Upgraded all GitHub Actions to Node.js 24-compatible versions (checkout@v5, setup-node@v5, upload-artifact@v6, download-artifact@v6, action-gh-release@v2)
 - Replaced deprecated martinbeentjes/npm-get-version-action with an inline step using $GITHUB_OUTPUT (fixes set-output deprecation)

 ## Release Integration Workflow: v1 vs v2 Build Logic

 ### Version Detection

 The `detect-version` job inspects `config/config.json` for a `runtimeVersion` field:
 - **`runtimeVersion: 2`** → runs the **v2** build and release flow
 - **Any other value or missing config file** → runs the **v1** build and release flow

 ### Build Differences

 | | **v1** | **v2** |
 |---|--------|--------|
 | **Dependencies** | `npm ci --omit=dev` (production only) | `npm ci` (all deps including devDependencies) |
 | **Build step** | None | `npm run build` (using Node 24), then reinstalls prod-only deps |
 | **Node switching** | Single version (Node 18) | Installs deps on Node 18 → switches to Node 24 for build → switches back to Node 18 for prod
reinstall |
 | **Archive name** | `{repo}-{version}+node-18.tgz` | `{repo}-v2-{version}+node-18.tgz` |

 ### Release Differences

 | | **v1** | **v2** |
 |---|--------|--------|
 | **Prerelease** | `false` (full release) | `true` (pre-release) |
 | **Make latest** | `true` | `false` |
 | **Release body** | Standard release notes | Prefixed with _"This is a v2 integration framework pre-release"_ |
 | **Download label** | Polarity Server 5.x | Polarity Server 5.x (v2 Integration) |

 Both flows produce a `.tgz` archive with a SHA256 hash and auto-generated commit logs since the last tag.

